### PR TITLE
ci: build distribution before uploading

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 
-name: Publish
+name: Publish Python Package
 on:
   release:
     types:
@@ -9,12 +9,38 @@ permissions:
   contents: read
 
 jobs:
-  pypi-publish:
-    name: upload release to PyPI
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distribution
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
     environment: release
     permissions:
       id-token: write
     steps:
-      - name: Publish package distributions to PyPI
+      - uses: actions/download-artifact@v4
+        with:
+          name: distribution
+          path: dist/
+      - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/changelog.d/3.fixed.md
+++ b/changelog.d/3.fixed.md
@@ -1,0 +1,1 @@
+Fix Github action for publishing to PyPI by first building the project before uploading.


### PR DESCRIPTION
We can't upload what we haven't built yet. Adding job to build the distribution first.

Closes #3 