### PR TITLE
fix: resolve a problem with jinja2 template rendering

### DIFF
--- a/airflow_memray/policies.py
+++ b/airflow_memray/policies.py
@@ -1,7 +1,6 @@
 import logging
 
-from airflow.decorators.base import DecoratedOperator
-from airflow.models import BaseOperator
+from airflow.models.taskinstance import TaskInstance
 from airflow.policies import hookimpl
 
 from airflow_memray.core import MEMRAY_TASK_PATTERNS, memray_func
@@ -9,15 +8,25 @@ from airflow_memray.core import MEMRAY_TASK_PATTERNS, memray_func
 logger = logging.getLogger(__name__)
 
 
+MEMRAY_ENABLED_KEY = "_memray_enabled"
+
+
 @hookimpl
-def task_policy(task: BaseOperator) -> None:
-    full_id = f"{task.dag_id}.{task.task_id}"
+def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
+    full_id = f"{task_instance.dag_id}.{task_instance.task_id}"
     if all(p.match(full_id) is None for p in MEMRAY_TASK_PATTERNS):
         return
 
-    if isinstance(task, DecoratedOperator):
-        task.python_callable = memray_func(task.python_callable)
-    else:
-        task.execute = memray_func(task.execute)  # type: ignore
+    task = task_instance.task
 
-    logger.debug("memray enabled for %s", task)
+    # somehow this hook can get called multiple times
+    # making sure we don't wrap the function multiple times
+    if getattr(task.__class__, MEMRAY_ENABLED_KEY, False):
+        return
+
+    exec_function = "execute"
+    original_execute = getattr(task.__class__, exec_function)
+    setattr(task.__class__, exec_function, memray_func(original_execute))
+    setattr(task.__class__, MEMRAY_ENABLED_KEY, True)
+
+    logger.info("memray enabled for %s", task_instance)

--- a/dags/memray_demo.py
+++ b/dags/memray_demo.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 from airflow.decorators import dag, task
+from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
@@ -46,6 +47,11 @@ def memray_demo():
     PythonOperator(
         task_id="memray_classic",
         python_callable=run,
+    )
+
+    BashOperator(
+        task_id="memray_bash",
+        bash_command='echo "ti_key={{ task_instance_key_str }}"',
     )
 
 


### PR DESCRIPTION
Setting `execute` on operator instance level had the effect that most of the base operator's utiliy functions (xcom return, jinja2 rendering, ...) were not working anymore.

Instead, setting `execute` on operator class level does not have the same effect. Furthermore, we do not need to discriminate between operator classes anymore.

Since changing class behavior can have side effects for other tasks, we now use a task instance mutation hook, which is only called on the worker for a particular task instance.

We also make sure, that the hook is only executed once. I've seen instances where the hook was executed multiple times for the same task instance, causing an issue with multiple memray trackers being created.